### PR TITLE
Add PyYAML to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fusepy
 pygit2
+pyyaml


### PR DESCRIPTION
We both already have [PyYAML](https://pyyaml.org/) installed in our hosts, but the following error occurs when running it from a vanilla environment:
```
root@56e35d41751c:/code# ./gitfuse
Traceback (most recent call last):
  File "/code/./gitfuse", line 11, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```